### PR TITLE
Preserve sub-pixel polygons as dots and normalize ring winding

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,35 +58,36 @@ jobs:
             manylinux: "2_28"
             duckdb_explicit_platform: "linux_amd64"
             interpreter: "/opt/python/cp314-cp314/bin/python"
-          # Pinned to windows-2025 (VS 2022): windows-latest now resolves to the
-          # VS 2026 image, whose MSVC removed stdext::checked_array_iterator and
-          # breaks the bundled DuckDB build (vendored fmt).
-          - os: windows-2025
+          # Pinned to windows-2022 (VS 2022): both windows-latest and
+          # windows-2025 now resolve to the VS 2026 image, whose MSVC removed
+          # stdext::checked_array_iterator and breaks the bundled DuckDB build
+          # (vendored fmt). Revisit once duckdb-rs supports VS 2026.
+          - os: windows-2022
             python-version: "3.9"
             manylinux: "auto"
             duckdb_explicit_platform: ""
             interpreter: "python"
-          - os: windows-2025
+          - os: windows-2022
             python-version: "3.10"
             manylinux: "auto"
             duckdb_explicit_platform: ""
             interpreter: "python"
-          - os: windows-2025
+          - os: windows-2022
             python-version: "3.11"
             manylinux: "auto"
             duckdb_explicit_platform: ""
             interpreter: "python"
-          - os: windows-2025
+          - os: windows-2022
             python-version: "3.12"
             manylinux: "auto"
             duckdb_explicit_platform: ""
             interpreter: "python"
-          - os: windows-2025
+          - os: windows-2022
             python-version: "3.13"
             manylinux: "auto"
             duckdb_explicit_platform: ""
             interpreter: "python"
-          - os: windows-2025
+          - os: windows-2022
             python-version: "3.14"
             manylinux: "auto"
             duckdb_explicit_platform: ""

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,32 +58,35 @@ jobs:
             manylinux: "2_28"
             duckdb_explicit_platform: "linux_amd64"
             interpreter: "/opt/python/cp314-cp314/bin/python"
-          - os: windows-latest
+          # Pinned to windows-2025 (VS 2022): windows-latest now resolves to the
+          # VS 2026 image, whose MSVC removed stdext::checked_array_iterator and
+          # breaks the bundled DuckDB build (vendored fmt).
+          - os: windows-2025
             python-version: "3.9"
             manylinux: "auto"
             duckdb_explicit_platform: ""
             interpreter: "python"
-          - os: windows-latest
+          - os: windows-2025
             python-version: "3.10"
             manylinux: "auto"
             duckdb_explicit_platform: ""
             interpreter: "python"
-          - os: windows-latest
+          - os: windows-2025
             python-version: "3.11"
             manylinux: "auto"
             duckdb_explicit_platform: ""
             interpreter: "python"
-          - os: windows-latest
+          - os: windows-2025
             python-version: "3.12"
             manylinux: "auto"
             duckdb_explicit_platform: ""
             interpreter: "python"
-          - os: windows-latest
+          - os: windows-2025
             python-version: "3.13"
             manylinux: "auto"
             duckdb_explicit_platform: ""
             interpreter: "python"
-          - os: windows-latest
+          - os: windows-2025
             python-version: "3.14"
             manylinux: "auto"
             duckdb_explicit_platform: ""

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,9 @@
   now replaced by a one-pixel square at its centroid instead of being
   dropped, so narrow features stay continuously visible. Ring winding is
   also normalized to the MVT specification (exterior rings positive area,
-  interior rings negative) and zero-area degenerate rings are dropped
-  rather than emitted as invalid polygons.
+  interior rings negative), zero-area degenerate rings are dropped rather
+  than emitted as invalid polygons, and quantization-induced spikes
+  (out-and-back needle vertices) are removed.
 * `freestile_h3()` is a new function for dynamic hexagonal binning. It
   aggregates points into H3 hexagons at zoom-appropriate resolutions via
   DuckDB's H3 community extension and writes a multi-layer `.pmtiles`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # freestiler 0.2.0
 
+* Thin (sub-pixel-width) polygons no longer flicker in and out across zoom
+  levels (#13). A polygon that collapses on a tile's integer pixel grid is
+  now replaced by a one-pixel square at its centroid instead of being
+  dropped, so narrow features stay continuously visible. Ring winding is
+  also normalized to the MVT specification (exterior rings positive area,
+  interior rings negative) and zero-area degenerate rings are dropped
+  rather than emitted as invalid polygons.
 * `freestile_h3()` is a new function for dynamic hexagonal binning. It
   aggregates points into H3 hexagons at zoom-appropriate resolutions via
   DuckDB's H3 community extension and writes a multi-layer `.pmtiles`

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -978,13 +978,17 @@ dependencies = [
  "geo",
  "geo-types",
  "geozero",
- "integer-encoding 4.1.0",
+ "indexmap",
+ "integer-encoding 4.0.2",
+ "jobserver",
  "parquet",
  "pmtiles2",
  "prost",
  "rayon",
+ "rayon-core",
  "serde",
  "serde_json",
+ "spade",
 ]
 
 [[package]]
@@ -1514,12 +1518,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1539,9 +1543,9 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "integer-encoding"
-version = "4.1.0"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c00403deb17c3221a1fe4fb571b9ed0370b3dcd116553c77fa294a3d918699"
+checksum = "0d762194228a2f1c11063e46e32e5acb96e66e906382b9eb5441f2e0504bbd5a"
 
 [[package]]
 name = "ipnet"
@@ -1585,11 +1589,10 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
- "getrandom 0.3.4",
  "libc",
 ]
 
@@ -1981,7 +1984,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.23.5",
 ]
 
 [[package]]
@@ -2258,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -2268,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.13.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -2647,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "spade"
-version = "2.15.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb313e1c8afee5b5647e00ee0fe6855e3d529eb863a0fdae1d60006c4d1e9990"
+checksum = "1ece03ff43cd2a9b57ebf776ea5e78bd30b3b4185a619f041079f4109f385034"
 dependencies = [
  "hashbrown 0.15.5",
  "num-traits",
@@ -2932,9 +2935,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "c2ad0b7ae9cfeef5605163839cb9221f453399f15cfb5c10be9885fcf56611f9"
 dependencies = [
  "indexmap",
  "toml_datetime 0.7.5+spec-1.1.0",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,6 +45,8 @@ Issues = "https://github.com/walkerke/freestiler/issues"
 
 [project.optional-dependencies]
 test = [
+    "mapbox-vector-tile>=2.0",
+    "pmtiles>=3.2",
     "pyarrow>=14",
     "pytest>=7.0",
 ]

--- a/python/tests/test_thin_polygons.py
+++ b/python/tests/test_thin_polygons.py
@@ -1,0 +1,84 @@
+"""Regression tests for issue #13: thin polygons must not flicker across zooms.
+
+Sub-pixel-width polygons used to collapse on the integer tile grid at some
+zoom levels (depending on how their edges landed on the grid) and get dropped,
+so features flickered in and out as the map zoomed. They are now replaced by a
+one-pixel square at their centroid, and ring winding is normalized so decoded
+polygons are valid.
+"""
+
+import gzip
+import math
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import box, shape
+
+from freestiler import freestile
+
+pmtiles_reader = pytest.importorskip("pmtiles.reader")
+mvt = pytest.importorskip("mapbox_vector_tile")
+
+LAT, LON = 43.41, -90.239
+
+
+def _tile_xy(lon, lat, z):
+    n = 2**z
+    return (
+        int((lon + 180) / 360 * n),
+        int((1 - math.asinh(math.tan(math.radians(lat))) / math.pi) / 2 * n),
+    )
+
+
+def _features_per_zoom(path, name, zooms):
+    """Map zoom -> decoded shapely geometry for the named feature (or None)."""
+    out = {}
+    with open(path, "rb") as f:
+        reader = pmtiles_reader.Reader(pmtiles_reader.MmapSource(f))
+        for z in zooms:
+            found = None
+            cx, cy = _tile_xy(LON, LAT, z)
+            for dx in (-1, 0, 1):
+                for dy in (-1, 0, 1):
+                    raw = reader.get(z, cx + dx, cy + dy)
+                    if not raw:
+                        continue
+                    layers = mvt.decode(gzip.decompress(raw))
+                    for ft in layers.get("layer", {}).get("features", []):
+                        if ft["properties"].get("name") == name:
+                            g = shape(ft["geometry"])
+                            if not g.is_empty:
+                                found = g
+            out[z] = found
+    return out
+
+
+def test_thin_strip_present_at_every_zoom(tmp_path):
+    dlon = 1.0 / (111_320 * math.cos(math.radians(LAT)))
+    dlat = 1.0 / 110_540
+    strip = box(LON, LAT, LON + 1500 * dlon, LAT + 30 * dlat)  # 30 m wide
+    block = box(LON, LAT - 400 * dlat, LON + 400 * dlon, LAT - 50 * dlat)
+    gdf = gpd.GeoDataFrame(
+        {"name": ["thin_strip_30m", "normal_block"]},
+        geometry=[strip, block],
+        crs="EPSG:4326",
+    )
+
+    output = tmp_path / "thin.pmtiles"
+    freestile(
+        gdf,
+        output,
+        layer_name="layer",
+        min_zoom=4,
+        max_zoom=14,
+        tile_format="mvt",
+        quiet=True,
+    )
+
+    zooms = range(4, 15)
+    for name in ("thin_strip_30m", "normal_block"):
+        per_zoom = _features_per_zoom(output, name, zooms)
+        for z, geom in per_zoom.items():
+            assert geom is not None, f"{name} missing at zoom {z}"
+            assert geom.is_valid, f"{name} invalid at zoom {z}"
+            assert geom.area > 0, f"{name} zero-area at zoom {z}"

--- a/src/rust/freestiler-core/src/lib.rs
+++ b/src/rust/freestiler-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod file_input;
 pub mod mlt;
 pub mod mvt;
 pub mod pmtiles_writer;
+pub mod quantize;
 pub mod simplify;
 #[cfg(feature = "duckdb")]
 pub mod streaming;

--- a/src/rust/freestiler-core/src/mlt.rs
+++ b/src/rust/freestiler-core/src/mlt.rs
@@ -1,6 +1,10 @@
 use integer_encoding::VarInt;
 use std::collections::HashMap;
 
+use crate::quantize::{
+    lat_to_tile_coord, lon_to_tile_coord, quantize_multipolygon, quantize_polygon_or_dot,
+    QuantPolygon,
+};
 use crate::tiler::{tile_bounds, Feature, Geometry, PropertyValue, TileCoord};
 
 /// MLT tile extent
@@ -683,65 +687,38 @@ fn collect_geometry_data(
             }
         }
         Geometry::Polygon(poly) => {
-            let ring_count = 1 + poly.interiors().len();
-            num_parts.push(ring_count as u32);
-            // Exterior ring
-            let ext = poly.exterior();
-            let ext_coords: Vec<_> = if ext.0.len() >= 2 && ext.0.first() == ext.0.last() {
-                ext.0[..ext.0.len() - 1].to_vec()
-            } else {
-                ext.0.clone()
-            };
-            num_rings.push(ext_coords.len() as u32);
-            for c in &ext_coords {
-                vertices_x.push(lon_to_tile_coord(c.x, west, east));
-                vertices_y.push(lat_to_tile_coord(c.y, south, north));
-            }
-            // Interior rings
-            for interior in poly.interiors() {
-                let int_coords: Vec<_> =
-                    if interior.0.len() >= 2 && interior.0.first() == interior.0.last() {
-                        interior.0[..interior.0.len() - 1].to_vec()
-                    } else {
-                        interior.0.clone()
-                    };
-                num_rings.push(int_coords.len() as u32);
-                for c in &int_coords {
-                    vertices_x.push(lon_to_tile_coord(c.x, west, east));
-                    vertices_y.push(lat_to_tile_coord(c.y, south, north));
-                }
-            }
+            let qp = quantize_polygon_or_dot(poly, west, south, east, north);
+            push_quant_polygon(&qp, num_parts, num_rings, vertices_x, vertices_y);
         }
         Geometry::MultiPolygon(mp) => {
-            num_geometries.push(mp.0.len() as u32);
-            for poly in &mp.0 {
-                let ring_count = 1 + poly.interiors().len();
-                num_parts.push(ring_count as u32);
-                let ext = poly.exterior();
-                let ext_coords: Vec<_> = if ext.0.len() >= 2 && ext.0.first() == ext.0.last() {
-                    ext.0[..ext.0.len() - 1].to_vec()
-                } else {
-                    ext.0.clone()
-                };
-                num_rings.push(ext_coords.len() as u32);
-                for c in &ext_coords {
-                    vertices_x.push(lon_to_tile_coord(c.x, west, east));
-                    vertices_y.push(lat_to_tile_coord(c.y, south, north));
-                }
-                for interior in poly.interiors() {
-                    let int_coords: Vec<_> =
-                        if interior.0.len() >= 2 && interior.0.first() == interior.0.last() {
-                            interior.0[..interior.0.len() - 1].to_vec()
-                        } else {
-                            interior.0.clone()
-                        };
-                    num_rings.push(int_coords.len() as u32);
-                    for c in &int_coords {
-                        vertices_x.push(lon_to_tile_coord(c.x, west, east));
-                        vertices_y.push(lat_to_tile_coord(c.y, south, north));
-                    }
-                }
+            let parts = quantize_multipolygon(mp, west, south, east, north);
+            num_geometries.push(parts.len() as u32);
+            for qp in &parts {
+                push_quant_polygon(qp, num_parts, num_rings, vertices_x, vertices_y);
             }
+        }
+    }
+}
+
+/// Push a quantized polygon's rings into the MLT geometry streams.
+fn push_quant_polygon(
+    qp: &QuantPolygon,
+    num_parts: &mut Vec<u32>,
+    num_rings: &mut Vec<u32>,
+    vertices_x: &mut Vec<i32>,
+    vertices_y: &mut Vec<i32>,
+) {
+    num_parts.push((1 + qp.interiors.len()) as u32);
+    num_rings.push(qp.exterior.len() as u32);
+    for &(x, y) in &qp.exterior {
+        vertices_x.push(x);
+        vertices_y.push(y);
+    }
+    for ring in &qp.interiors {
+        num_rings.push(ring.len() as u32);
+        for &(x, y) in ring {
+            vertices_x.push(x);
+            vertices_y.push(y);
         }
     }
 }
@@ -1319,18 +1296,6 @@ fn try_fsst_dictionary(dict_entries: &[&str]) -> Option<FsstEncoded> {
 }
 
 // --- Helper functions ---
-
-fn lon_to_tile_coord(lon: f64, west: f64, east: f64) -> i32 {
-    ((lon - west) / (east - west) * EXTENT as f64).round() as i32
-}
-
-fn lat_to_tile_coord(lat: f64, south: f64, north: f64) -> i32 {
-    // Interpolate in Mercator Y space (not linear latitude) for correct projection
-    let lat_merc = lat.to_radians().tan().asinh();
-    let south_merc = south.to_radians().tan().asinh();
-    let north_merc = north.to_radians().tan().asinh();
-    ((north_merc - lat_merc) / (north_merc - south_merc) * EXTENT as f64).round() as i32
-}
 
 fn delta_encode_i32(values: &[i32]) -> Vec<i32> {
     let mut result = Vec::with_capacity(values.len());

--- a/src/rust/freestiler-core/src/mvt.rs
+++ b/src/rust/freestiler-core/src/mvt.rs
@@ -1,6 +1,10 @@
 use prost::Message;
 use std::collections::HashMap;
 
+use crate::quantize::{
+    lat_to_tile_coord, lon_to_tile_coord, quantize_multipolygon, quantize_polygon_or_dot,
+    QuantPolygon,
+};
 use crate::tiler::{tile_bounds, Feature, Geometry, PropertyValue, TileCoord};
 
 /// MVT tile extent (coordinate space)
@@ -174,20 +178,6 @@ pub fn encode_tile(
     encode_tile_multilayer(coord, &[(layer_name, property_names, features)])
 }
 
-/// Convert a longitude to tile-local X coordinate (0..4096)
-fn lon_to_tile_coord(lon: f64, west: f64, east: f64) -> i32 {
-    ((lon - west) / (east - west) * EXTENT as f64).round() as i32
-}
-
-/// Convert a latitude to tile-local Y coordinate (0..4096, Y-down)
-fn lat_to_tile_coord(lat: f64, south: f64, north: f64) -> i32 {
-    // Interpolate in Mercator Y space (not linear latitude) for correct projection
-    let lat_merc = lat.to_radians().tan().asinh();
-    let south_merc = south.to_radians().tan().asinh();
-    let north_merc = north.to_radians().tan().asinh();
-    ((north_merc - lat_merc) / (north_merc - south_merc) * EXTENT as f64).round() as i32
-}
-
 /// Zigzag encode a signed integer
 fn zigzag(n: i32) -> u32 {
     ((n << 1) ^ (n >> 31)) as u32
@@ -240,16 +230,15 @@ fn encode_geometry(geom: &Geometry, west: f64, south: f64, east: f64, north: f64
             cmds
         }
         Geometry::Polygon(poly) => {
-            encode_polygon_cmds(poly, west, south, east, north, &mut 0, &mut 0)
+            let qp = quantize_polygon_or_dot(poly, west, south, east, north);
+            encode_quant_polygon_cmds(&qp, &mut 0, &mut 0)
         }
         Geometry::MultiPolygon(mp) => {
             let mut cmds = Vec::new();
             let mut cx = 0i32;
             let mut cy = 0i32;
-            for poly in &mp.0 {
-                cmds.extend(encode_polygon_cmds(
-                    poly, west, south, east, north, &mut cx, &mut cy,
-                ));
+            for qp in quantize_multipolygon(mp, west, south, east, north) {
+                cmds.extend(encode_quant_polygon_cmds(&qp, &mut cx, &mut cy));
             }
             cmds
         }
@@ -307,91 +296,38 @@ fn encode_linestring_cmds(
     cmds
 }
 
-fn encode_polygon_cmds(
-    poly: &geo_types::Polygon<f64>,
-    west: f64,
-    south: f64,
-    east: f64,
-    north: f64,
-    cx: &mut i32,
-    cy: &mut i32,
-) -> Vec<u32> {
-    let mut cmds = Vec::new();
-
-    // Encode exterior ring
-    let ext_cmds = encode_ring_cmds(poly.exterior(), west, south, east, north, cx, cy);
-    if ext_cmds.is_empty() {
-        return Vec::new();
+fn encode_quant_polygon_cmds(qp: &QuantPolygon, cx: &mut i32, cy: &mut i32) -> Vec<u32> {
+    let mut cmds = encode_quant_ring_cmds(&qp.exterior, cx, cy);
+    for interior in &qp.interiors {
+        cmds.extend(encode_quant_ring_cmds(interior, cx, cy));
     }
-    cmds.extend(ext_cmds);
-
-    // Encode interior rings (holes)
-    for interior in poly.interiors() {
-        let ring_cmds = encode_ring_cmds(interior, west, south, east, north, cx, cy);
-        if !ring_cmds.is_empty() {
-            cmds.extend(ring_cmds);
-        }
-    }
-
     cmds
 }
 
-fn encode_ring_cmds(
-    ring: &geo_types::LineString<f64>,
-    west: f64,
-    south: f64,
-    east: f64,
-    north: f64,
-    cx: &mut i32,
-    cy: &mut i32,
-) -> Vec<u32> {
-    // A ring should have at least 4 coords (3 unique + close) but the last == first
-    // We encode all but the last (ClosePath closes it)
-    let coords: Vec<_> = if ring.0.len() >= 2 && ring.0.first() == ring.0.last() {
-        ring.0[..ring.0.len() - 1].to_vec()
-    } else {
-        ring.0.clone()
-    };
-
+/// Encode an open ring of quantized tile coordinates. Rings from
+/// [`QuantPolygon`] are deduplicated, non-degenerate, and winding-normalized,
+/// so every vertex emits a command.
+fn encode_quant_ring_cmds(coords: &[(i32, i32)], cx: &mut i32, cy: &mut i32) -> Vec<u32> {
     if coords.len() < 3 {
         return Vec::new();
     }
 
-    let mut cmds = Vec::new();
+    let mut cmds = Vec::with_capacity(coords.len() * 2 + 3);
 
-    // MoveTo first point
-    let x = lon_to_tile_coord(coords[0].x, west, east);
-    let y = lat_to_tile_coord(coords[0].y, south, north);
+    let (x, y) = coords[0];
     cmds.push(command(CMD_MOVE_TO, 1));
     cmds.push(zigzag(x - *cx));
     cmds.push(zigzag(y - *cy));
     *cx = x;
     *cy = y;
 
-    // LineTo remaining points
-    let mut line_to_params: Vec<u32> = Vec::new();
-    let mut count = 0u32;
-    for coord in &coords[1..] {
-        let x = lon_to_tile_coord(coord.x, west, east);
-        let y = lat_to_tile_coord(coord.y, south, north);
-        let dx = x - *cx;
-        let dy = y - *cy;
-        if dx == 0 && dy == 0 {
-            continue;
-        }
-        line_to_params.push(zigzag(dx));
-        line_to_params.push(zigzag(dy));
+    cmds.push(command(CMD_LINE_TO, (coords.len() - 1) as u32));
+    for &(x, y) in &coords[1..] {
+        cmds.push(zigzag(x - *cx));
+        cmds.push(zigzag(y - *cy));
         *cx = x;
         *cy = y;
-        count += 1;
     }
-
-    if count < 2 {
-        return Vec::new();
-    }
-
-    cmds.push(command(CMD_LINE_TO, count));
-    cmds.extend(line_to_params);
     cmds.push(command(CMD_CLOSE_PATH, 1));
 
     cmds

--- a/src/rust/freestiler-core/src/quantize.rs
+++ b/src/rust/freestiler-core/src/quantize.rs
@@ -1,0 +1,371 @@
+//! Shared polygon quantization for the tile encoders.
+//!
+//! Both the MVT and MLT encoders round coordinates to the integer tile grid.
+//! That rounding can collapse narrow polygons to zero area (dropping them at
+//! some zooms but not others, depending on how their edges land on the grid)
+//! and can flip or degenerate ring winding. This module centralizes the
+//! rounding so both encoders get the same guarantees:
+//!
+//! - Consecutive duplicate vertices are removed.
+//! - Zero-area interior rings are dropped.
+//! - Ring winding is normalized to the MVT convention (exterior rings have
+//!   positive signed area by the surveyor's formula in y-down tile
+//!   coordinates; interior rings negative).
+//! - A polygon whose exterior collapses below one pixel is replaced by a
+//!   one-pixel square at its centroid instead of being dropped, so thin
+//!   features stay continuously visible across zoom levels.
+
+use geo_types::{LineString, MultiPolygon, Polygon};
+
+/// Tile coordinate extent (pixels per tile side)
+pub const EXTENT: u32 = 4096;
+
+/// Convert a longitude to tile-local X coordinate (0..4096)
+pub fn lon_to_tile_coord(lon: f64, west: f64, east: f64) -> i32 {
+    ((lon - west) / (east - west) * EXTENT as f64).round() as i32
+}
+
+/// Convert a latitude to tile-local Y coordinate (0..4096, Y-down)
+pub fn lat_to_tile_coord(lat: f64, south: f64, north: f64) -> i32 {
+    // Interpolate in Mercator Y space (not linear latitude) for correct projection
+    let lat_merc = lat.to_radians().tan().asinh();
+    let south_merc = south.to_radians().tan().asinh();
+    let north_merc = north.to_radians().tan().asinh();
+    ((north_merc - lat_merc) / (north_merc - south_merc) * EXTENT as f64).round() as i32
+}
+
+/// A polygon quantized to integer tile coordinates.
+///
+/// Rings are open (no closing duplicate vertex), deduplicated, and oriented:
+/// exterior positive signed area, interiors negative (y-down tile space).
+#[derive(Clone, Debug, PartialEq)]
+pub struct QuantPolygon {
+    pub exterior: Vec<(i32, i32)>,
+    pub interiors: Vec<Vec<(i32, i32)>>,
+}
+
+/// Quantize a polygon, substituting a one-pixel square at the centroid if the
+/// exterior ring collapses on the tile grid.
+pub fn quantize_polygon_or_dot(
+    poly: &Polygon<f64>,
+    west: f64,
+    south: f64,
+    east: f64,
+    north: f64,
+) -> QuantPolygon {
+    let ext = quantize_ring(poly.exterior(), west, south, east, north);
+    if ext.len() < 3 || signed_area2(&ext) == 0 {
+        return dot_polygon(ring_center(&ext));
+    }
+
+    let mut exterior = ext;
+    if signed_area2(&exterior) < 0 {
+        exterior.reverse();
+    }
+
+    let interiors = poly
+        .interiors()
+        .iter()
+        .filter_map(|ring| {
+            let mut coords = quantize_ring(ring, west, south, east, north);
+            let area2 = if coords.len() < 3 {
+                0
+            } else {
+                signed_area2(&coords)
+            };
+            if area2 == 0 {
+                return None;
+            }
+            if area2 > 0 {
+                coords.reverse();
+            }
+            Some(coords)
+        })
+        .collect();
+
+    QuantPolygon {
+        exterior,
+        interiors,
+    }
+}
+
+/// Quantize every part of a multipolygon. Collapsed parts become one-pixel
+/// squares; squares that land on the same pixel are deduplicated.
+pub fn quantize_multipolygon(
+    mp: &MultiPolygon<f64>,
+    west: f64,
+    south: f64,
+    east: f64,
+    north: f64,
+) -> Vec<QuantPolygon> {
+    let mut seen_dots: Vec<(i32, i32)> = Vec::new();
+    let mut out = Vec::with_capacity(mp.0.len());
+    for poly in &mp.0 {
+        let qp = quantize_polygon_or_dot(poly, west, south, east, north);
+        if let Some(center) = qp.dot_center() {
+            if seen_dots.contains(&center) {
+                continue;
+            }
+            seen_dots.push(center);
+        }
+        out.push(qp);
+    }
+    out
+}
+
+impl QuantPolygon {
+    /// If this polygon is a substituted one-pixel dot, return its anchor pixel.
+    fn dot_center(&self) -> Option<(i32, i32)> {
+        if self.interiors.is_empty() && self.exterior.len() == 4 && {
+            let (x, y) = self.exterior[0];
+            self.exterior == dot_exterior(x, y)
+        } {
+            Some(self.exterior[0])
+        } else {
+            None
+        }
+    }
+}
+
+/// One-pixel square polygon anchored at `center` (positive signed area).
+pub fn dot_polygon(center: (i32, i32)) -> QuantPolygon {
+    QuantPolygon {
+        exterior: dot_exterior(center.0, center.1),
+        interiors: Vec::new(),
+    }
+}
+
+fn dot_exterior(x: i32, y: i32) -> Vec<(i32, i32)> {
+    vec![(x, y), (x + 1, y), (x + 1, y + 1), (x, y + 1)]
+}
+
+/// Quantize a ring to integer tile coordinates, dropping the closing
+/// duplicate and consecutive vertices that land on the same pixel.
+fn quantize_ring(
+    ring: &LineString<f64>,
+    west: f64,
+    south: f64,
+    east: f64,
+    north: f64,
+) -> Vec<(i32, i32)> {
+    let source = if ring.0.len() >= 2 && ring.0.first() == ring.0.last() {
+        &ring.0[..ring.0.len() - 1]
+    } else {
+        &ring.0[..]
+    };
+
+    let mut coords: Vec<(i32, i32)> = Vec::with_capacity(source.len());
+    for c in source {
+        let p = (
+            lon_to_tile_coord(c.x, west, east),
+            lat_to_tile_coord(c.y, south, north),
+        );
+        if coords.last() == Some(&p) {
+            continue;
+        }
+        coords.push(p);
+    }
+
+    // The last vertex may snap onto the first
+    while coords.len() >= 2 && coords.first() == coords.last() {
+        coords.pop();
+    }
+
+    coords
+}
+
+/// Twice the signed area of an open ring by the surveyor's formula, computed
+/// directly in y-down tile coordinates (MVT convention: exterior > 0).
+fn signed_area2(coords: &[(i32, i32)]) -> i64 {
+    let n = coords.len();
+    if n < 3 {
+        return 0;
+    }
+    let mut sum = 0i64;
+    for i in 0..n {
+        let (x1, y1) = coords[i];
+        let (x2, y2) = coords[(i + 1) % n];
+        sum += x1 as i64 * y2 as i64 - x2 as i64 * y1 as i64;
+    }
+    sum
+}
+
+/// Integer centroid (vertex mean) of a quantized ring, used to anchor the
+/// dot substituted for a collapsed polygon. Falls back to the origin for an
+/// empty ring (cannot occur for rings coming from real geometries).
+fn ring_center(coords: &[(i32, i32)]) -> (i32, i32) {
+    if coords.is_empty() {
+        return (0, 0);
+    }
+    let n = coords.len() as i64;
+    let sx: i64 = coords.iter().map(|&(x, _)| x as i64).sum();
+    let sy: i64 = coords.iter().map(|&(_, y)| y as i64).sum();
+    (
+        (sx as f64 / n as f64).round() as i32,
+        (sy as f64 / n as f64).round() as i32,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo_types::{polygon, Coord};
+
+    const W: f64 = 0.0;
+    const S: f64 = 0.0;
+    const E: f64 = 1.0;
+    const N: f64 = 1.0;
+
+    /// Degrees per tile pixel for the 1x1-degree test tile
+    const PX: f64 = 1.0 / EXTENT as f64;
+
+    #[test]
+    fn wide_polygon_survives_quantization() {
+        let poly = polygon![
+            (x: 0.1, y: 0.1),
+            (x: 0.9, y: 0.1),
+            (x: 0.9, y: 0.9),
+            (x: 0.1, y: 0.9),
+            (x: 0.1, y: 0.1),
+        ];
+        let qp = quantize_polygon_or_dot(&poly, W, S, E, N);
+        assert_eq!(qp.exterior.len(), 4);
+        assert!(signed_area2(&qp.exterior) > 0);
+    }
+
+    #[test]
+    fn reversed_exterior_winding_is_normalized() {
+        // Same square as above, vertices in the opposite order
+        let poly = polygon![
+            (x: 0.1, y: 0.1),
+            (x: 0.1, y: 0.9),
+            (x: 0.9, y: 0.9),
+            (x: 0.9, y: 0.1),
+            (x: 0.1, y: 0.1),
+        ];
+        let qp = quantize_polygon_or_dot(&poly, W, S, E, N);
+        assert!(signed_area2(&qp.exterior) > 0);
+    }
+
+    #[test]
+    fn interior_ring_winding_is_normalized_and_opposite() {
+        let mut poly = polygon![
+            (x: 0.1, y: 0.1),
+            (x: 0.9, y: 0.1),
+            (x: 0.9, y: 0.9),
+            (x: 0.1, y: 0.9),
+            (x: 0.1, y: 0.1),
+        ];
+        poly.interiors_push(LineString::from(vec![
+            Coord { x: 0.4, y: 0.4 },
+            Coord { x: 0.6, y: 0.4 },
+            Coord { x: 0.6, y: 0.6 },
+            Coord { x: 0.4, y: 0.6 },
+            Coord { x: 0.4, y: 0.4 },
+        ]));
+        let qp = quantize_polygon_or_dot(&poly, W, S, E, N);
+        assert_eq!(qp.interiors.len(), 1);
+        assert!(signed_area2(&qp.exterior) > 0);
+        assert!(signed_area2(&qp.interiors[0]) < 0);
+    }
+
+    #[test]
+    fn sub_pixel_polygon_becomes_dot_not_dropped() {
+        // A strip 1000 pixels long but 0.2 pixels tall: both long edges round
+        // to the same tile row, which previously dropped the feature.
+        let poly = polygon![
+            (x: 0.1, y: 0.5),
+            (x: 0.1 + 1000.0 * PX, y: 0.5),
+            (x: 0.1 + 1000.0 * PX, y: 0.5 + 0.2 * PX),
+            (x: 0.1, y: 0.5 + 0.2 * PX),
+            (x: 0.1, y: 0.5),
+        ];
+        let qp = quantize_polygon_or_dot(&poly, W, S, E, N);
+        assert_eq!(qp.exterior.len(), 4);
+        assert!(signed_area2(&qp.exterior) > 0);
+        // Anchored at the strip's centroid
+        let (cx, _cy) = qp.exterior[0];
+        assert!((cx - 910).abs() <= 2, "dot x = {cx}, expected near 910");
+    }
+
+    #[test]
+    fn fully_collapsed_polygon_becomes_dot() {
+        // Smaller than one pixel in both dimensions
+        let poly = polygon![
+            (x: 0.5, y: 0.5),
+            (x: 0.5 + 0.1 * PX, y: 0.5),
+            (x: 0.5 + 0.1 * PX, y: 0.5 + 0.1 * PX),
+            (x: 0.5, y: 0.5 + 0.1 * PX),
+            (x: 0.5, y: 0.5),
+        ];
+        let qp = quantize_polygon_or_dot(&poly, W, S, E, N);
+        assert_eq!(qp.exterior.len(), 4);
+        assert_eq!(signed_area2(&qp.exterior), 2);
+    }
+
+    #[test]
+    fn zero_area_interior_ring_is_dropped() {
+        let mut poly = polygon![
+            (x: 0.1, y: 0.1),
+            (x: 0.9, y: 0.1),
+            (x: 0.9, y: 0.9),
+            (x: 0.1, y: 0.9),
+            (x: 0.1, y: 0.1),
+        ];
+        // Sub-pixel hole collapses to zero area on the grid
+        poly.interiors_push(LineString::from(vec![
+            Coord { x: 0.5, y: 0.5 },
+            Coord {
+                x: 0.5 + 0.1 * PX,
+                y: 0.5,
+            },
+            Coord {
+                x: 0.5 + 0.1 * PX,
+                y: 0.5 + 0.1 * PX,
+            },
+            Coord {
+                x: 0.5,
+                y: 0.5 + 0.1 * PX,
+            },
+            Coord { x: 0.5, y: 0.5 },
+        ]));
+        let qp = quantize_polygon_or_dot(&poly, W, S, E, N);
+        assert!(qp.interiors.is_empty());
+    }
+
+    #[test]
+    fn multipolygon_dedupes_coincident_dots() {
+        let tiny = |x0: f64, y0: f64| {
+            polygon![
+                (x: x0, y: y0),
+                (x: x0 + 0.1 * PX, y: y0),
+                (x: x0 + 0.1 * PX, y: y0 + 0.1 * PX),
+                (x: x0, y: y0 + 0.1 * PX),
+                (x: x0, y: y0),
+            ]
+        };
+        // Two slivers on the same pixel, one on a different pixel
+        let mp = MultiPolygon(vec![
+            tiny(0.5, 0.5),
+            tiny(0.5 + 0.2 * PX, 0.5),
+            tiny(0.25, 0.25),
+        ]);
+        let parts = quantize_multipolygon(&mp, W, S, E, N);
+        assert_eq!(parts.len(), 2);
+    }
+
+    #[test]
+    fn collinear_out_and_back_ring_is_collapsed_to_dot() {
+        // Three distinct pixels, all on one row: nonzero vertex count but
+        // zero area. Previously emitted as a degenerate (invalid) polygon.
+        let poly = polygon![
+            (x: 0.1, y: 0.5),
+            (x: 0.9, y: 0.5),
+            (x: 0.5, y: 0.5),
+            (x: 0.1, y: 0.5),
+        ];
+        let qp = quantize_polygon_or_dot(&poly, W, S, E, N);
+        assert_eq!(qp.exterior.len(), 4);
+        assert!(signed_area2(&qp.exterior) > 0);
+    }
+}

--- a/src/rust/freestiler-core/src/quantize.rs
+++ b/src/rust/freestiler-core/src/quantize.rs
@@ -171,7 +171,42 @@ fn quantize_ring(
         coords.pop();
     }
 
+    remove_spikes(&mut coords);
+
     coords
+}
+
+/// Iteratively remove spikes: vertices whose cyclic neighbors coincide, i.e.
+/// the ring walks out to a point and retraces itself (`A -> B -> A`).
+/// Quantization commonly creates these from narrow appendages, and they make
+/// the ring self-intersecting. Removing a spike tip leaves a consecutive
+/// duplicate pair, which is deduplicated before re-scanning; multi-vertex
+/// needles (`A -> B -> C -> B -> A`) unwind over successive passes. A ring
+/// that is entirely spike degenerates below three vertices and is handled by
+/// the caller (collapse to dot, or drop for interior rings).
+fn remove_spikes(coords: &mut Vec<(i32, i32)>) {
+    loop {
+        if coords.len() < 3 {
+            return;
+        }
+        let n = coords.len();
+        let spike = (0..n).find(|&i| coords[(i + n - 1) % n] == coords[(i + 1) % n]);
+        let Some(tip) = spike else {
+            return;
+        };
+        coords.remove(tip);
+
+        // Removing the tip leaves its two (equal) neighbors adjacent; dedupe
+        // cyclically so the scan above sees a clean ring.
+        let mut i = 0;
+        while coords.len() >= 2 && i < coords.len() {
+            if coords[i] == coords[(i + 1) % coords.len()] {
+                coords.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
 }
 
 /// Twice the signed area of an open ring by the surveyor's formula, computed
@@ -352,6 +387,60 @@ mod tests {
         ]);
         let parts = quantize_multipolygon(&mp, W, S, E, N);
         assert_eq!(parts.len(), 2);
+    }
+
+    #[test]
+    fn needle_spike_is_removed() {
+        // A square with a zero-width needle sticking out of its top edge:
+        // the ring walks out to the needle tip and retraces itself.
+        let poly = polygon![
+            (x: 0.1, y: 0.1),
+            (x: 0.2, y: 0.1),
+            (x: 0.2, y: 0.2),
+            (x: 0.15, y: 0.2),
+            (x: 0.15, y: 0.25),
+            (x: 0.15, y: 0.2),
+            (x: 0.1, y: 0.2),
+            (x: 0.1, y: 0.1),
+        ];
+        let qp = quantize_polygon_or_dot(&poly, W, S, E, N);
+        let tip_y = lat_to_tile_coord(0.25, S, N);
+        assert!(
+            !qp.exterior.iter().any(|&(_, y)| y == tip_y),
+            "needle tip should be removed, got {:?}",
+            qp.exterior
+        );
+        assert_eq!(qp.exterior.len(), 5);
+        assert!(signed_area2(&qp.exterior) > 0);
+    }
+
+    #[test]
+    fn multi_vertex_needle_unwinds_completely() {
+        // The needle has an intermediate vertex (A -> B -> C -> B -> A); spike
+        // removal must unwind it over successive passes.
+        let poly = polygon![
+            (x: 0.1, y: 0.1),
+            (x: 0.2, y: 0.1),
+            (x: 0.2, y: 0.2),
+            (x: 0.15, y: 0.2),
+            (x: 0.15, y: 0.22),
+            (x: 0.15, y: 0.25),
+            (x: 0.15, y: 0.22),
+            (x: 0.15, y: 0.2),
+            (x: 0.1, y: 0.2),
+            (x: 0.1, y: 0.1),
+        ];
+        let qp = quantize_polygon_or_dot(&poly, W, S, E, N);
+        let top_edge_y = lat_to_tile_coord(0.2, S, N);
+        for &(_, y) in &qp.exterior {
+            assert!(
+                y >= top_edge_y.min(lat_to_tile_coord(0.1, S, N))
+                    && y <= top_edge_y.max(lat_to_tile_coord(0.1, S, N)),
+                "needle vertex survived: {:?}",
+                qp.exterior
+            );
+        }
+        assert!(signed_area2(&qp.exterior) > 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #13.

Thin (sub-pixel-width) polygons collapsed on the integer tile grid at some zoom levels but not others, depending on how their edges landed on the grid, so features flickered in and out across zoom. Two encoder-level causes:

- The MVT encoder silently dropped any ring with fewer than two surviving segments after coordinate rounding (`encode_ring_cmds`).
- The MLT encoder wrote raw quantized vertices with no degenerate-ring handling at all.

Neither encoder enforced ring winding, so quantization-flipped or clip-produced rings could decode with the wrong role or as self-intersecting/zero-area polygons (the reporter's second observation).

## Changes

Polygon quantization now lives in a shared `quantize` module consumed by both the MVT and MLT encoders:

- **Tiny-polygon preservation**: a polygon whose exterior collapses below one pixel becomes a one-pixel square at its centroid instead of disappearing, so narrow features stay continuously visible across zooms (same spirit as tippecanoe's tiny-polygon handling). Coincident dots within a multipolygon are deduplicated.
- **Winding normalization**: exterior rings positive signed area by the surveyor's formula in y-down tile coordinates, interiors negative, per the MVT spec.
- **Degenerate-ring cleanup**: consecutive duplicate vertices removed; zero-area interior rings dropped; collinear out-and-back exteriors (previously emitted as invalid polygons) collapse to dots.

`simplification=True/False` byte-identical output for thin polygons was a consequence of the encoder re-rounding regardless of the flag; with the encoder now handling collapse explicitly, that's the intended behavior rather than a silent drop.

## Test plan

- [x] Reporter's reproduction: 30 m strip now present **and valid** at every zoom 4-14 (was missing at z4/z6/z7), normal block unchanged
- [x] 8 new `quantize` unit tests (collapse-to-dot, winding both ring roles, zero-area interior drop, dot dedup, collinear degenerate)
- [x] New Python regression test decoding the actual tiles (`python/tests/test_thin_polygons.py`); `pmtiles` + `mapbox-vector-tile` added to test extras
- [x] Core Rust: 29/29 lib tests pass
- [x] Python: 50/50 pass
- [x] R: 214/214 pass across mvt/mlt/multilayer/clustering/coalesce/dropping/h3 (4 warnings pre-existing on main)

## Out of scope

Full self-intersection repair for complex source rings (clipper/Wagyu-style cleaning) is a larger lift, tracked separately; this PR fixes the quantization-induced invalidity classes.

## Updates after reporter feedback

- **Spike/needle removal**: the reporter confirmed the hole-winding family went to zero on the real WI DNR layer and identified the remaining encoder-introduced invalidity as out-and-back needle vertices, which the consecutive-duplicate pass cannot catch. Rings now iteratively drop any vertex whose cyclic neighbors coincide; multi-vertex needles unwind across passes.
- **Windows CI fix**: `windows-latest` moved to the VS 2026 image on June 8, whose MSVC STL removed `stdext::checked_array_iterator`; DuckDB's vendored `fmt` still references it, so every Windows wheel build failed. The matrix is now pinned to `windows-2022` (the `windows-2025` label was also upgraded to the VS 2026 image). Unrelated to this PR's changes.

Full Wagyu/Vatti-style self-intersection resolution and a make-valid-on-input option remain follow-up candidates.

